### PR TITLE
Refresh the blog typography with Instrument Sans and Space Grotesk

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -42,7 +42,7 @@ const isActive = (path: string) => {
       {currentPath !== "/" && (
         <a
           href="/"
-          class="absolute py-1 text-xl leading-8 font-semibold whitespace-nowrap hover:text-accent sm:static sm:my-auto sm:text-2xl sm:leading-none"
+          class="absolute py-1 text-xl leading-8 font-display font-semibold whitespace-nowrap hover:text-accent sm:static sm:my-auto sm:text-2xl sm:leading-none"
         >
           {SITE.title}
         </a>

--- a/src/components/HeadlineCard.astro
+++ b/src/components/HeadlineCard.astro
@@ -4,7 +4,7 @@ import type { CollectionEntry } from "astro:content";
 import { getPath } from "@/utils/getPath";
 import Datetime from "./Datetime.astro";
 
-export interface Props extends CollectionEntry<"blog"> {}
+export type Props = CollectionEntry<"blog">;
 
 const { data, id, filePath } = Astro.props;
 const { title, pubDatetime, modDatetime, timezone } = data;
@@ -20,7 +20,7 @@ const { title, pubDatetime, modDatetime, timezone } = data;
     />
     <a
       href={getPath(id, filePath)}
-      class="text-lg text-accent hover:underline decoration-dashed underline-offset-4"
+      class="font-display text-lg text-accent hover:underline decoration-dashed underline-offset-4"
       style={{ viewTransitionName: slugifyStr(title) }}
     >
       {title}

--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -19,7 +19,7 @@ const { frontmatter } = Astro.props;
   <Header />
   <Breadcrumb />
   <main id="main-content">
-    <section id="about" class="app-prose mb-28 max-w-app prose-img:border-0">
+    <section id="about" class="app-prose mb-28 max-w-content prose-img:border-0">
       <h1 class="text-2xl tracking-wider sm:text-3xl">{frontmatter.title}</h1>
       <slot />
     </section>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -57,6 +57,12 @@ const structuredData = {
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&family=Instrument+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Space+Grotesk:wght@400;500;700&display=swap"
+    />
     <link rel="icon" type="image/png" href={Logo.src} />
     <link rel="canonical" href={canonicalURL} />
     <meta name="generator" content={Astro.generator} />

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -112,7 +112,7 @@ const nextPost =
     </div>
     <article
       id="article"
-      class="app-prose mx-auto mt-8 max-w-app prose-pre:bg-(--shiki-light-bg) dark:prose-pre:bg-(--shiki-dark-bg)"
+      class="app-prose mx-auto mt-8 max-w-content prose-pre:bg-(--shiki-light-bg) dark:prose-pre:bg-(--shiki-dark-bg)"
     >
       <Content />
     </article>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -91,7 +91,7 @@ const backUrl = SITE.showBackButton ? `${Astro.url.pathname}` : "/";
 
 <style is:global>
   #pagefind-search {
-    --pagefind-ui-font: var(--font-mono);
+    --pagefind-ui-font: var(--font-sans);
     --pagefind-ui-text: var(--foreground);
     --pagefind-ui-background: var(--background);
     --pagefind-ui-border: var(--border);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -29,6 +29,15 @@ html[data-theme="dark"] {
   --color-accent: var(--accent);
   --color-muted: var(--muted);
   --color-border: var(--border);
+  --font-sans:
+    "Instrument Sans", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  --font-display:
+    "Space Grotesk", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  --font-mono:
+    "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
 
   --height-screen-90: 90vh;
   --height-screen-50: 50vh;
@@ -50,7 +59,24 @@ html[data-theme="dark"] {
     @apply overflow-y-scroll scroll-smooth;
   }
   body {
-    @apply flex min-h-svh flex-col bg-background font-mono text-foreground selection:bg-accent/75 selection:text-background;
+    @apply flex min-h-svh flex-col bg-background font-sans text-foreground antialiased selection:bg-accent/75 selection:text-background;
+  }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  nav,
+  button,
+  time {
+    @apply font-display;
+  }
+  code,
+  pre,
+  kbd,
+  samp {
+    @apply font-mono;
   }
   a,
   button {
@@ -67,7 +93,15 @@ html[data-theme="dark"] {
 }
 
 @utility max-w-app {
-  @apply max-w-3xl;
+  max-width: 688px;
+}
+
+@utility max-w-content {
+  max-width: 688px;
+}
+
+@utility font-display {
+  font-family: var(--font-display);
 }
 
 @utility no-scrollbar {

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -4,13 +4,15 @@
   /* ===== Override default Tailwind Typography styles ===== */
   .app-prose {
     @apply prose;
+    font-size: 1.12rem;
+    line-height: 1.58;
 
     h1,
     h2,
     h3,
     h4,
     th {
-      @apply mb-3 text-foreground;
+      @apply mb-3 font-display text-foreground;
     }
 
     h3 {
@@ -22,9 +24,8 @@
     ol,
     ul,
     figcaption,
-    table,
-    code {
-      @apply text-foreground tracking-tight;
+    table {
+      @apply text-foreground;
     }
     
     strong,
@@ -72,7 +73,7 @@
     }
 
     code {
-      @apply rounded bg-muted/75 p-1 break-words text-foreground before:content-none after:content-none;
+      @apply rounded bg-muted/75 p-1 break-words font-mono text-foreground before:content-none after:content-none;
     }
 
     .astro-code code {
@@ -80,7 +81,7 @@
     }
 
     blockquote {
-      @apply border-s-accent/80 break-words opacity-80;
+      @apply border-s-accent/80 break-words font-sans opacity-80;
       quotes: none;
     }
     
@@ -98,7 +99,7 @@
     }
 
     pre {
-      @apply focus-visible:border-transparent focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-dashed;
+      @apply font-mono focus-visible:border-transparent focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-dashed;
     }
   }
 

--- a/src/utils/loadGoogleFont.ts
+++ b/src/utils/loadGoogleFont.ts
@@ -36,15 +36,27 @@ async function loadGoogleFonts(
 > {
   const fontsConfig = [
     {
-      name: "IBM Plex Mono",
-      font: "IBM+Plex+Mono",
+      name: "Space Grotesk",
+      font: "Space+Grotesk",
       weight: 400,
       style: "normal",
     },
     {
-      name: "IBM Plex Mono",
-      font: "IBM+Plex+Mono",
+      name: "Space Grotesk",
+      font: "Space+Grotesk",
       weight: 700,
+      style: "bold",
+    },
+    {
+      name: "Instrument Sans",
+      font: "Instrument+Sans",
+      weight: 400,
+      style: "normal",
+    },
+    {
+      name: "Instrument Sans",
+      font: "Instrument+Sans",
+      weight: 600,
       style: "bold",
     },
   ];

--- a/src/utils/og-templates/post.js
+++ b/src/utils/og-templates/post.js
@@ -149,6 +149,7 @@ export default async post => {
                     margin: "20px",
                     width: "90%",
                     height: "90%",
+                    fontFamily: "Instrument Sans",
                   },
                   children: [
                     {
@@ -156,6 +157,7 @@ export default async post => {
                       props: {
                         style: {
                           fontSize: 72,
+                          fontFamily: "Space Grotesk",
                           fontWeight: "bold",
                           maxHeight: "84%",
                           overflow: "hidden",
@@ -191,6 +193,7 @@ export default async post => {
                                   props: {
                                     style: {
                                       overflow: "hidden",
+                                      fontFamily: "Space Grotesk",
                                       fontWeight: "bold",
                                     },
                                     children: post.data.author,
@@ -202,7 +205,11 @@ export default async post => {
                           {
                             type: "span",
                             props: {
-                              style: { overflow: "hidden", fontWeight: "bold" },
+                              style: {
+                                overflow: "hidden",
+                                fontFamily: "Space Grotesk",
+                                fontWeight: "bold",
+                              },
                               children: SITE.title,
                             },
                           },

--- a/src/utils/og-templates/site.js
+++ b/src/utils/og-templates/site.js
@@ -58,6 +58,7 @@ export default async () => {
                     margin: "20px",
                     width: "90%",
                     height: "90%",
+                    fontFamily: "Instrument Sans",
                   },
                   children: [
                     {
@@ -77,7 +78,11 @@ export default async () => {
                           {
                             type: "p",
                             props: {
-                              style: { fontSize: 72, fontWeight: "bold" },
+                              style: {
+                                fontSize: 72,
+                                fontFamily: "Space Grotesk",
+                                fontWeight: "bold",
+                              },
                               children: SITE.title,
                             },
                           },
@@ -104,7 +109,11 @@ export default async () => {
                         children: {
                           type: "span",
                           props: {
-                            style: { overflow: "hidden", fontWeight: "bold" },
+                            style: {
+                              overflow: "hidden",
+                              fontFamily: "Space Grotesk",
+                              fontWeight: "bold",
+                            },
                             children: new URL(SITE.website).hostname,
                           },
                         },


### PR DESCRIPTION
## Summary
- switch body copy to Instrument Sans and display typography to Space Grotesk while keeping code in IBM Plex Mono
- narrow the shared content width and tune prose sizing and rhythm to fit the selected direction
- update search and generated OG assets so the typography stays consistent across the site

## Validation
- `npm run build`
- `npm run lint` (fails only on the repo's existing baseline issues in `convert-to-astropaper.js`, `src/components/LinkButton.astro`, and `src/pages/rss.xml.ts`)
