### PR TITLE
Update About page

### DIFF
--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -5,29 +5,48 @@ title: "About"
 
 import Socials from "../components/Socials.astro";
 
-Hello! I'm **YJ Soon**, from and in Singapore. Depending on the time of day, I'm a teacher, programmer, designer, person who draws chickens (phrased this way because "chicken drawer" would be a notably different activity), and/or business owner.
+Hello! I'm **YJ Soon**, from and in Singapore. I teach, design, code, and build things. Depending on the time of day, I'm also a programmer, person who draws chickens (phrased this way because "chicken drawer" would be a notably different activity), and/or business owner.
+
+Most of my work happens at [Tinkertanker](https://tinkertanker.com), the company I co-founded, where we teach coding and making to learners of all ages. I also spend money on AI coding subscriptions at a rate I'd rather not discuss.
 
 <Socials />
 
 ## Work
 
 - [Tinkertanker](https://tinkertanker.com): The company I co-founded with my friends Akmal and Steven.
-  - [Tinkercademy](https://tinkercademy.com): Education branding of Tinkertanker. We teach coding and making to learners of all ages.
+  - [Tinkercademy](https://tinkercademy.com): Our education brand. We teach coding and making to learners of all ages, covering agentic engineering, introductory programming, app development, web development, game development, and more.
   - [Swift Accelerator](https://swiftinsg.org): A year-long talent development programme I run for aspiring young app developers, supported by IMDA and Apple.
-  - [Tinkerer's Guide to the micro:bit Galaxy](https://tgttmg.tk.sg): A book we wrote during the pandemic.
-  - [IC Photo](https://icphoto.tinkertanker.com) was our first iOS app. Hundreds of thousands of downloads! Years and years of neglect!
-- [Get Hacking](https://gethacking.com): Online store run by [Tinker Class](https://tinkerclass.tech), a joint venture between Tinkertanker and Classroom HK.
-- [Tinkermind](https://tinkermind.sg): A maker education company that Tinkertanker holds a minority stake in.
+- [Agentic Builders Collective](https://agenticbuilders.sg): A Singapore community I co-founded for people building with AI agents. You can add yourself to our website by pull request—just point your favourite coding agent at [the repository](https://github.com/agentic-builders-collective/agentic-builders-collective.github.io) and demand to be added.
+- [Get Hacking](https://gethacking.com): An online store run by [Tinker Class](https://tinkerclass.tech), a joint venture between Tinkertanker and Classroom HK.
+- [Tinkermind](https://tinkermind.sg): A maker education company in which Tinkertanker holds a minority stake.
 
-## Projects
+## Things I've made
 
-- Programming projects
-  - [This blog](https://github.com/yjsoon/blog), running on [Astro](https://astro.build) on the [Astro Paper theme](https://github.com/satnaing/astro-paper).
-  - [Bamboobot Cert Generator](https://bamboobot.tk.sg): Interactive NextJS app to generate certificates of achievement with text embedded in PDF. [Source](https://github.com/tinkertanker/bamboobot-cert-generator).
-  - [YNAB Rewards](https://rewards.soon.sg): A rewards tracker for people who use [YNAB](https://ynab.com) and obsessively categorise their transactions to maximise their credit cards rewards. [Source](https://github.com/yjsoon/ynab-rewards-tracker).
-  - [JustNow for Mac](https://justnow.tk.sg): A lightweight screen recall tool — I liked Rewind.app, but it went away. JustNow captures what's on your screen so you can find things you closed or lost. Useful if you're easily distracted, which I am. [Open source.](https://github.com/yjsoon/justnow)
-  - [DF Style Linked List WordPress plugin](https://github.com/yjsoon/df-style-linked-list_wordpress-plugin): An old WordPress plugin for my old blog, to make "link posts" a la [Daring Fireball](https://daringfireball.net). Haven't touched for over a decade, sorry!
-- Super, super old 3D animations my friends and I made in high school in the late 90s, using 3D Studio R4 or something:
-  - [Teapots: Once Upon A Time in China](https://youtube.com/watch?v=Mw1mhCZvwLQ)
-  - [The Duckness of Space](https://youtube.com/watch?v=vuekAy5mGec)
-  - [3D Qbasic Gorillas](https://www.youtube.com/watch?v=rm7kP7eSrD8)
+### Personal projects
+
+- [**JustNow**](https://justnow.tk.sg): A native macOS menu bar app that keeps a short, fully local rewind history of your screen, with OCR, search, screenshots, and zero telemetry. [Source](https://github.com/yjsoon/justnow).
+- [**YNAB Rewards**](https://rewards.soon.sg): A rewards tracker for people who obsessively categorise their YNAB transactions to maximise their credit card rewards. Hello! [Source](https://github.com/yjsoon/ynab-rewards-tracker).
+- [**This blog**](https://github.com/yjsoon/blog): Built with [Astro](https://astro.build), originally based on the [AstroPaper theme](https://github.com/satnaing/astro-paper), and subjected to continual tinkering.
+
+### Work and teaching projects
+
+- [**Bamboobot**](https://bamboobot.tk.sg): Generates certificates of achievement with text properly embedded in the PDF. [Source](https://github.com/tinkertanker/bamboobot-cert-generator).
+- [**Classroom Widgets**](https://widgets.tk.sg): A real-time teacher and student activity board with polls, questions, timers, QR codes, randomisers, handouts, feedback, and voice commands. [Source](https://github.com/tinkertanker/classroom-widgets).
+- [**Discord Drive Uploader**](https://github.com/tinkertanker/discord-drive-uploader): A self-hosted Discord bot and setup interface that uploads photos and videos from mapped Discord channels into Google Drive folders.
+- [**Points Accelerator**](https://github.com/tinkertanker/points-accelerator): A Discord economy and assignment bot for class communities, with group points, personal wallets, a marketplace, betting, lucky draws, and an OAuth dashboard.
+- [**TKrobot Stickers**](https://stickers.tk.sg): Stickers for the company mascot, made by complaining extensively at imagegen. [Source](https://github.com/tinkertanker/tkrobot-stickers).
+- [**Vibbit**](https://vibbit.tk.sg): An AI coding assistant for micro:bit MakeCode, packaged as a Chrome extension and bookmarklet, with a managed classroom backend and a bring-your-own-key mode. [Source](https://github.com/tinkertanker/vibbit).
+- [**IC Photo**](https://icphoto.tinkertanker.com): Our first iOS app. Hundreds of thousands of downloads! Years and years of neglect!
+
+### Older but still around
+
+- [**DF-Style Linked List**](https://github.com/yjsoon/df-style-linked-list_wordpress-plugin): A WordPress plugin I haven't touched in over a decade, which remains my most-starred repository. Yay?
+- [**Tinkerer's Guide to the micro:bit Galaxy**](https://tgttmg.tk.sg): A book we wrote during the pandemic.
+
+### Unreasonably old animations
+
+Some 3D animations my friends and I made in high school in the late 1990s, using 3D Studio R4 or something:
+
+- [Teapots: Once Upon a Time in China](https://youtube.com/watch?v=Mw1mhCZvwLQ)
+- [The Duckness of Space](https://youtube.com/watch?v=vuekAy5mGec)
+- [3D QBasic Gorillas](https://www.youtube.com/watch?v=rm7kP7eSrD8)


### PR DESCRIPTION
## Summary

- refresh the introduction to match the current GitHub profile
- add Agentic Builders Collective and current work/teaching projects
- reorganize projects into personal, work and teaching, older, and archival sections
- preserve the page's personal tone and older animations

## Validation

- `npm run build`
- `npx prettier --check src/pages/about.mdx`
- desktop and mobile browser previews