### PR TITLE
Update Agentic Builders link

### DIFF
--- a/src/data/blog/2026-06-24-introduction-claw-breeding-youths.mdx
+++ b/src/data/blog/2026-06-24-introduction-claw-breeding-youths.mdx
@@ -90,7 +90,7 @@ And, because this was a DSTA camp, the students built some fairly interesting de
 
 ## And a special guest from the OpenClaw Foundation
 
-A day before the camp, [Queenie Wu](https://sg.linkedin.com/in/mengyun-wu-0123) sent a message in the [Agentic Builders Collective](https://www.linkedin.com/company/agentic-builders-collective) chat mentioning that the Chief Architect of OpenClaw, [Vincent Koc](https://github.com/vincentkoc), was in town. We chatted over DM, and Queenie made it happen — the kids actually got to hear from the man himself! The kids asked a ton of questions, and got some great advice about how to think about agentic coding, and were encouraged to just have fun. Always good advice.
+A day before the camp, [Queenie Wu](https://sg.linkedin.com/in/mengyun-wu-0123) sent a message in the [Agentic Builders Collective](https://agenticbuilders.sg) chat mentioning that the Chief Architect of OpenClaw, [Vincent Koc](https://github.com/vincentkoc), was in town. We chatted over DM, and Queenie made it happen — the kids actually got to hear from the man himself! The kids asked a ton of questions, and got some great advice about how to think about agentic coding, and were encouraged to just have fun. Always good advice.
 
 <figure>
   <img src={img6.src} alt="Vincent Koc speaking to students at the bootcamp" class="w-full" />


### PR DESCRIPTION
## Summary

- link Agentic Builders Collective to `agenticbuilders.sg` instead of its LinkedIn company page

## Scope

- one URL change in the OpenClaw bootcamp post
- excludes the local RSS work and `blog-staging/` draft

## Validation

- `git diff --check`
- clean-branch CI will run on this pull request