### PR TITLE
Fix barely visible post ending text in dark mode

### DIFF
--- a/docs/content-workflow.md
+++ b/docs/content-workflow.md
@@ -25,7 +25,7 @@ Keep presentation compact and literal:
 - If the same destination appears later as a named link, remove a redundant earlier link without changing the surrounding wording.
 - Use italics for a short inline quotation when requested; use a blockquote for a long quotation and do not retain quotation marks that duplicate the blockquote styling.
 - Keep consecutive bullet items adjacent unless the source clearly contains separate paragraphs; do not insert blank lines between ordinary bullets.
-- Keep the final LinkedIn backlink as one compact paragraph so its punctuation does not render on a line by itself.
+- Keep the final LinkedIn backlink as one compact paragraph so its punctuation does not render on a line by itself. Use the `LinkedInBacklink` component for that closer so it stays readable in both light and dark themes.
 
 ## Links
 

--- a/src/components/LinkedInBacklink.astro
+++ b/src/components/LinkedInBacklink.astro
@@ -1,0 +1,12 @@
+---
+export interface Props {
+  href: string;
+}
+
+const { href } = Astro.props;
+---
+
+<p class="post-backlink">
+  To discuss, or if you feel compelled to press some kind of reaction button,
+  feel free to comment on the <a href={href}>LinkedIn version of this post</a>.
+</p>

--- a/src/data/blog/2026-06-24-introduction-claw-breeding-youths.mdx
+++ b/src/data/blog/2026-06-24-introduction-claw-breeding-youths.mdx
@@ -16,6 +16,7 @@ import img4 from "../../assets/images/2026/06/claw-breeding-4-cereal-soup.jpg";
 import img5 from "../../assets/images/2026/06/claw-breeding-5-chaos.jpg";
 import img6 from "../../assets/images/2026/06/claw-breeding-6-vincent-talk.jpg";
 import img7 from "../../assets/images/2026/06/claw-breeding-7-crab-pose.jpg";
+import LinkedInBacklink from "@/components/LinkedInBacklink.astro";
 
 Last week, my [Tinkercademy](https://www.tinkercademy.com) colleagues and I ran an **[OpenClaw](https://openclaw.ai)** Bootcamp for nearly a hundred high school kids for [DSTA](https://www.dsta.gov.sg)’s Young Defence Scientists Programme! It was *very* weird. And quite a lot of fun. The students learned about agentic coding, SSH, servers, Markdown files, connecting channels, SOUL, and more; I thought I'd write a bit about it to share, since I hadn't heard much before about OpenClaw being used as a teaching tool (believe me, I certainly *tried* to find a curriculum to adapt).
 
@@ -122,6 +123,4 @@ Huge thanks in particular to [Sean Wong](https://sg.linkedin.com/in/seanwong-sc)
 
 Not many thanks at all to Claude Fable, who, during its brief existence, generated one of the most overwrought and over-engineered curricula I've ever seen. Sorry to our facilitators for having made you read through that, only to come up with the actual curriculum the night before.
 
-<div class="mt-6 text-sm opacity-60">
-  To discuss, or if you feel compelled to press some kind of reaction button, feel free to comment on the <a href="https://www.linkedin.com/pulse/introduction-claw-breeding-youths-yj-soon-m8ade?utm_source=share&utm_medium=member_ios&utm_campaign" class="text-current underline decoration-dashed underline-offset-4">LinkedIn version of this post</a>.
-</div>
+<LinkedInBacklink href="https://www.linkedin.com/pulse/introduction-claw-breeding-youths-yj-soon-m8ade?utm_source=share&utm_medium=member_ios&utm_campaign" />

--- a/src/data/blog/2026-07-25-the-delightful-version.mdx
+++ b/src/data/blog/2026-07-25-the-delightful-version.mdx
@@ -8,6 +8,8 @@ featured: false
 draft: false
 ---
 
+import LinkedInBacklink from "@/components/LinkedInBacklink.astro";
+
 I burned a terrifyingly large number of Claude Fable tokens trying to animate _one word_ nicely on our [Tinkercademy](https://tinkercademy.com) homepage.
 
 <video
@@ -42,5 +44,4 @@ Source: ["The Death of Good Enough", which I wrote about in March](/posts/2026-0
 
 What a time to build, man.
 
-{/* prettier-ignore */}
-<div class="mt-6 text-sm opacity-60">To discuss, or if you feel compelled to press some kind of reaction button, feel free to comment on the <a href="https://www.linkedin.com/feed/update/urn:li:activity:7486697745295073280/" class="text-current underline decoration-dashed underline-offset-4">LinkedIn version of this post</a>.</div>
+<LinkedInBacklink href="https://www.linkedin.com/feed/update/urn:li:activity:7486697745295073280/" />

--- a/src/data/blog/2026-08-06-thanks-codex-for-the-slop-design.mdx
+++ b/src/data/blog/2026-08-06-thanks-codex-for-the-slop-design.mdx
@@ -9,6 +9,7 @@ draft: false
 ---
 
 import YouTubeEmbed from "@/components/YouTubeEmbed.astro";
+import LinkedInBacklink from "@/components/LinkedInBacklink.astro";
 
 Last weekend, I realised I had a ChatGPT/Codex “banked reset” expiring at 4am. This meant that I could use up my Codex tokens way before my usual weekly reset, and restart with a fresh quota.
 
@@ -38,5 +39,4 @@ I’d add that having a point of view comes from _exposure_: someone who’s see
 
 So, err, thanks Codex for the slop design? Maybe 5.7 will do better.
 
-{/* prettier-ignore */}
-<div class="mt-6 text-sm opacity-60">To discuss, or if you feel compelled to press some kind of reaction button, feel free to comment on the <a href="https://www.linkedin.com/posts/yjsoon_last-weekend-i-realised-i-had-a-chatgpt-activity-7491015343113588736-2ki1" class="text-current underline decoration-dashed underline-offset-4">LinkedIn version of this post</a>.</div>
+<LinkedInBacklink href="https://www.linkedin.com/posts/yjsoon_last-weekend-i-realised-i-had-a-chatgpt-activity-7491015343113588736-2ki1" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -33,11 +33,11 @@ html[data-theme="dark"] {
   --color-muted-foreground: var(--muted-foreground);
   --color-border: var(--border);
   --font-sans:
-    "Instrument Sans", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-    "Segoe UI", sans-serif;
+    "Instrument Sans", ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-display:
-    "Space Grotesk", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-    "Segoe UI", sans-serif;
+    "Space Grotesk", ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-mono:
     "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,6 +9,7 @@ html[data-theme="light"] {
   --foreground: #282728;
   --accent: #b85450;
   --muted: #ece9e3;
+  --muted-foreground: #5c5956;
   --border: #e2dfd9;
 }
 
@@ -19,6 +20,7 @@ html[data-theme="dark"] {
   --accent: #d4706c;
   /* Subtle surfaces on dark */
   --muted: #333333;
+  --muted-foreground: #c4c8d0;
   /* More separation on dark */
   --border: #555555;
 }
@@ -28,6 +30,7 @@ html[data-theme="dark"] {
   --color-foreground: var(--foreground);
   --color-accent: var(--accent);
   --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
   --color-border: var(--border);
   --font-sans:
     "Instrument Sans", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -4,6 +4,7 @@
   /* ===== Override default Tailwind Typography styles ===== */
   .app-prose {
     @apply prose;
+    --tw-prose-body: var(--foreground);
     font-size: 1.12rem;
     line-height: 1.58;
 
@@ -108,6 +109,14 @@
 
     pre {
       @apply font-mono focus-visible:border-transparent focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-dashed;
+    }
+
+    .post-backlink {
+      @apply mt-6 text-sm text-muted-foreground;
+    }
+
+    .post-backlink a {
+      @apply text-current underline decoration-dashed underline-offset-4 hover:opacity-80;
     }
   }
 

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -91,6 +91,7 @@
 
     blockquote {
       @apply border-s-accent/80 font-sans break-words opacity-80;
+
       quotes: none;
     }
 
@@ -116,7 +117,7 @@
     }
 
     .post-backlink a {
-      @apply text-current underline decoration-dashed underline-offset-4 hover:opacity-80;
+      @apply text-current underline decoration-dashed underline-offset-4 hover:opacity-100;
     }
   }
 

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -36,7 +36,7 @@
     table {
       @apply text-foreground;
     }
-    
+
     strong,
     b {
       @apply font-bold;
@@ -82,7 +82,7 @@
     }
 
     code {
-      @apply rounded bg-muted/75 p-1 break-words font-mono text-foreground before:content-none after:content-none;
+      @apply rounded bg-muted/75 p-1 font-mono break-words text-foreground before:content-none after:content-none;
     }
 
     .astro-code code {
@@ -90,10 +90,10 @@
     }
 
     blockquote {
-      @apply border-s-accent/80 break-words font-sans opacity-80;
+      @apply border-s-accent/80 font-sans break-words opacity-80;
       quotes: none;
     }
-    
+
     blockquote:before,
     blockquote:after {
       content: none !important;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The LinkedIn discussion closer at the end of adapted posts was nearly invisible in dark mode.

**Cause:** the closer lived in a raw `div` with `opacity-60`. Tailwind Typography’s default body colour is a light-mode gray, and only `p` / list elements were overridden to the theme foreground. The closer therefore stayed dark gray, then faded further, against the dark background.

**Fix:**
- Add a `--muted-foreground` token that stays readable in both themes
- Point `.app-prose` body colour at the theme foreground so custom HTML inherits correctly
- Replace the copied HTML closer with a `LinkedInBacklink` component styled as secondary text
- Point the content workflow at that component so future adaptations keep the same contrast

The closer copy is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00ca1-0f97-7044-a9a0-ee44751e9306?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00ca1-0f97-7044-a9a0-ee44751e9306&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

