### PR TITLE
Add seo-graph for JSON-LD, llms.txt, and agent markdown

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,5 @@
 engine-strict=true
+
+# @iannuttall/seo-graph-astro declares an optional Astro 7 peer.
+# This site stays on Astro 5; the integration hooks we use exist there.
+legacy-peer-deps=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Repository guide for coding agents. Keep this file short; put durable project co
 - [src/content.config.ts](src/content.config.ts): blog content schema and loader rules.
 - [astro.config.ts](astro.config.ts): Astro integrations, markdown plugins, Shiki, and env schema.
 - [docs/content-workflow.md](docs/content-workflow.md): rules for adapting social posts into blog posts.
+- [docs/seo-graph.md](docs/seo-graph.md): schema.org JSON-LD, llms.txt, and agent-markdown integration.
 
 ## Working Rules
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Personal blog of YJ Soon, built with [Astro](https://astro.build/).
 - **Theme**: Based on [AstroPaper](https://github.com/satnaing/astro-paper) by Sat Naing
 - **Styling**: [TailwindCSS](https://tailwindcss.com/)
 - **Search**: [Pagefind](https://pagefind.app/)
+- **SEO**: [seo-graph](https://github.com/iannuttall/seo-graph) for JSON-LD, `llms.txt`, and Markdown twins (see [docs/seo-graph.md](docs/seo-graph.md))
 - **Interactive Components**: [React](https://react.dev/)
 
 ## Running Locally
@@ -47,6 +48,7 @@ When asked to “commit and push,” publish the requested changes all the way t
   original page or https://yjsoon.com.
 
 Notes
+
 - Third‑party trademarks and logos are the property of their respective owners.
 - Some images or embeds may have their own licenses; where applicable, those
   are indicated in the post.

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -32,6 +32,18 @@ export default defineConfig({
         summary: SITE.desc,
         details:
           "Personal blog of YJ Soon. Content is licensed [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). RSS is at /rss.xml. A corpus-wide JSON-LD graph is at /schema/blog.json.",
+        sections: [
+          {
+            heading: "Start here",
+            items: [
+              { path: "/", label: "Home" },
+              { path: "/about", label: "About" },
+              { path: "/posts", label: "All posts" },
+              { path: "/archives", label: "Archives" },
+            ],
+          },
+        ],
+        autoSection: { heading: "All pages", position: "after" },
       },
     }),
   ],

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -3,6 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import sitemap from "@astrojs/sitemap";
 import react from "@astrojs/react";
 import mdx from "@astrojs/mdx";
+import { agentMarkdown } from "@iannuttall/seo-graph-astro";
 import remarkToc from "remark-toc";
 import remarkCollapse from "remark-collapse";
 import {
@@ -24,6 +25,14 @@ export default defineConfig({
     mdx(),
     sitemap({
       filter: page => SITE.showArchives || !page.endsWith("/archives"),
+    }),
+    agentMarkdown({
+      llmsTxt: {
+        title: SITE.title,
+        summary: SITE.desc,
+        details:
+          "Personal blog of YJ Soon. Content is licensed [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). RSS is at /rss.xml. A corpus-wide JSON-LD graph is at /schema/blog.json.",
+      },
     }),
   ],
   markdown: {

--- a/docs/seo-graph.md
+++ b/docs/seo-graph.md
@@ -12,7 +12,13 @@ engines and AI agents can read the same structured facts.
 
 The Astro package lists Astro 7 as an optional peer. This project stays on
 Astro 5 and installs with `legacy-peer-deps` (see `.npmrc`). The hooks we
-use (`astro:config:*` and `astro:build:done`) exist in Astro 5.
+use (`astro:config:*` and `astro:build:done`) exist in Astro 5. That install
+mode also nests some transitive packages, so `vite` and the React types are
+listed directly.
+
+Page URLs in the graph use trailing slashes to match Astro's directory
+output and the last breadcrumb item. Empty post descriptions fall back to
+`SITE.desc` so the agent-markdown pipeline has a meta description to read.
 
 ## Page JSON-LD
 

--- a/docs/seo-graph.md
+++ b/docs/seo-graph.md
@@ -67,3 +67,6 @@ use the `.md` twins and `llms.txt` instead.
 - A Worker handler for `Accept: text/markdown` at canonical URLs
 - `llms-full.txt` (optional one-file export; not part of the llms.txt v2
   proposal)
+- Astro 7 upgrade: tracked in
+  [issue #11](https://github.com/yjsoon/blog/issues/11). Not required for
+  this integration.

--- a/docs/seo-graph.md
+++ b/docs/seo-graph.md
@@ -1,0 +1,63 @@
+# Agent-ready SEO
+
+This site uses [seo-graph](https://github.com/iannuttall/seo-graph) so search
+engines and AI agents can read the same structured facts.
+
+## What is installed
+
+- [`@iannuttall/seo-graph-core`](https://www.npmjs.com/package/@iannuttall/seo-graph-core)
+  builds linked schema.org `@graph` objects.
+- [`@iannuttall/seo-graph-astro`](https://www.npmjs.com/package/@iannuttall/seo-graph-astro)
+  emits Markdown twins, `llms.txt`, and a route manifest at build time.
+
+The Astro package lists Astro 7 as an optional peer. This project stays on
+Astro 5 and installs with `legacy-peer-deps` (see `.npmrc`). The hooks we
+use (`astro:config:*` and `astro:build:done`) exist in Astro 5.
+
+## Page JSON-LD
+
+`src/utils/seoGraph.ts` follows the personal-blog recipe: a site-wide
+`WebSite`, `Person`, `Blog`, and navigation graph, plus a per-page
+`WebPage` / `ProfilePage` / `CollectionPage` and `BlogPosting` where
+needed. `src/layouts/Layout.astro` renders the assembled graph.
+
+Do not hand-write a second JSON-LD blob on a page. Pass `schemaKind`,
+breadcrumbs, and post fields into `Layout` instead.
+
+## Build artefacts
+
+`agentMarkdown()` walks the built HTML and writes:
+
+- a `.md` twin beside each content page
+- `/llms.txt`
+- `/agent-routes.json`
+- Cloudflare `_headers` rules for the Markdown routes
+
+Decorative chrome should stay outside `<main>` or use
+`data-agent-markdown="exclude"`. The converter already drops `nav`,
+`footer`, `form`, and `button`.
+
+Collection-source Markdown endpoints are intentionally not wired. The
+build hook also writes `.md` twins and will refuse to overwrite a
+different file at the same path.
+
+## Discovery URLs
+
+| URL | Purpose |
+| --- | --- |
+| `/llms.txt` | Curated + generated index of Markdown twins |
+| `/agent-routes.json` | HTML ↔ Markdown map with hashes and token counts |
+| `/schema/blog.json` | Corpus-wide blog `@graph` |
+| `/schemamap.xml` | List of schema endpoints |
+| `/.well-known/api-catalog` | RFC 9727 catalogue of machine-readable routes |
+
+Runtime `Accept: text/markdown` negotiation at canonical HTML URLs needs
+a Cloudflare Worker. This site is a static Pages deploy, so agents should
+use the `.md` twins and `llms.txt` instead.
+
+## Left for later
+
+- IndexNow key + incremental submit on production deploys
+- A Worker handler for `Accept: text/markdown` at canonical URLs
+- `llms-full.txt` (optional one-file export; not part of the llms.txt v2
+  proposal)

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "schema-dts": "^2.0.0",
         "sharp": "^0.34.2",
         "tailwindcss": "^4.1.11",
+        "vite": "^6.4.3",
         "yet-another-react-lightbox": "^3.25.0"
       },
       "devDependencies": {
@@ -41,6 +42,8 @@
         "@tailwindcss/typography": "^0.5.16",
         "@types/lodash.kebabcase": "^4.1.9",
         "@types/markdown-it": "^14.1.2",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
         "@types/sanitize-html": "^2.16.0",
         "@typescript-eslint/parser": "^8.36.0",
         "eslint": "^9.30.1",
@@ -1098,80 +1101,6 @@
         "ufo": "^1.5.4"
       }
     },
-    "node_modules/@astrojs/cloudflare/node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "jiti": ">=1.21.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@astrojs/cloudflare/node_modules/workerd": {
       "version": "1.20250428.0",
       "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250428.0.tgz",
@@ -1387,80 +1316,6 @@
         "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
         "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@astrojs/react/node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "jiti": ">=1.21.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
       }
     },
     "node_modules/@astrojs/rss": {
@@ -4868,6 +4723,26 @@
         "undici-types": "~7.10.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@types/sanitize-html": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.0.tgz",
@@ -5975,80 +5850,6 @@
         "@img/sharp-win32-x64": "0.33.5"
       }
     },
-    "node_modules/astro/node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "jiti": ">=1.21.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/astrojs-compiler-sync": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/astrojs-compiler-sync/-/astrojs-compiler-sync-1.1.1.tgz",
@@ -6831,6 +6632,13 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
       "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -13247,6 +13055,80 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/vitefu": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@astrojs/react": "^4.3.0",
         "@astrojs/rss": "^4.0.12",
         "@astrojs/sitemap": "^3.4.1",
+        "@iannuttall/seo-graph-astro": "^0.0.6",
+        "@iannuttall/seo-graph-core": "^0.0.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@resvg/resvg-js": "^2.6.2",
         "@tailwindcss/vite": "^4.1.11",
@@ -27,6 +29,7 @@
         "remark-toc": "^9.0.0",
         "sanitize-html": "^2.17.0",
         "satori": "^0.15.2",
+        "schema-dts": "^2.0.0",
         "sharp": "^0.34.2",
         "tailwindcss": "^4.1.11",
         "yet-another-react-lightbox": "^3.25.0"
@@ -2699,6 +2702,52 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@iannuttall/seo-graph-astro": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@iannuttall/seo-graph-astro/-/seo-graph-astro-0.0.6.tgz",
+      "integrity": "sha512-sfchpVP10dPBiYnRGUH4GoqvHzPJXYmFriJOGuc/KjopX0QA1cn4qaEiSCXNQ+rpNqfslNXE4P9RTwnRWYIavw==",
+      "license": "MIT",
+      "dependencies": {
+        "@iannuttall/seo-graph-core": "0.0.3",
+        "schema-dts": "^2.0.0",
+        "zod": "^4.4.3"
+      },
+      "funding": {
+        "url": "https://github.com/iannuttall"
+      },
+      "peerDependencies": {
+        "astro": ">=7.0.0 <8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "astro": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@iannuttall/seo-graph-astro/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@iannuttall/seo-graph-core": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@iannuttall/seo-graph-core/-/seo-graph-core-0.0.3.tgz",
+      "integrity": "sha512-/zBfFR55w6CDXclWpb99ZPq72VPNzUq3AX7NtrsjMTRFVqH+JAtm2b3nX7Qhm+KNA1Jiui6t4XOaU2Mg8GC6cA==",
+      "license": "MIT",
+      "dependencies": {
+        "linkedom": "0.18.13",
+        "schema-dts": "^2.0.0",
+        "turndown": "7.2.4",
+        "turndown-plugin-gfm": "1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/iannuttall"
+      }
+    },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.3.tgz",
@@ -3210,6 +3259,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4813,26 +4868,6 @@
         "undici-types": "~7.10.0"
       }
     },
-    "node_modules/@types/react": {
-      "version": "19.1.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
-      "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "19.1.9",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
-      "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^19.0.0"
-      }
-    },
     "node_modules/@types/sanitize-html": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.0.tgz",
@@ -6111,6 +6146,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
+      "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/boxen": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
@@ -6631,6 +6679,105 @@
         "node": ">=16"
       }
     },
+    "node_modules/css-select": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
+      "integrity": "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0",
+        "css-what": "^8.0.0",
+        "domhandler": "^6.0.1",
+        "domutils": "^4.0.2",
+        "nth-check": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select/node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/css-select/node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/css-select/node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/css-select/node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/css-select/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/css-to-react-native": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
@@ -6655,6 +6802,19 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/css-what": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
+      "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -6667,12 +6827,11 @@
         "node": ">=4"
       }
     },
-    "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT",
-      "peer": true
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
       "version": "2.0.2",
@@ -8755,6 +8914,61 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/linkedom": {
+      "version": "0.18.13",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.13.tgz",
+      "integrity": "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==",
+      "license": "ISC",
+      "dependencies": {
+        "css-select": "^7.0.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.1.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/linkedom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/linkedom/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -10685,6 +10899,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
+      "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/ofetch": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.1.tgz",
@@ -11935,6 +12165,27 @@
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
     },
+    "node_modules/schema-dts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-2.0.0.tgz",
+      "integrity": "sha512-t7NoCy3Rn5GHGx6p7s1qIYK/AeIb8ZxJNR9WUNFkwMv2CiiGZBmqqYWc2FlZVm5ZbiHMY4OvBWhj7QtyrFO2Jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "schema-dts-lib": "^1.0.0"
+      }
+    },
+    "node_modules/schema-dts-lib": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/schema-dts-lib/-/schema-dts-lib-1.0.0.tgz",
+      "integrity": "sha512-9MEO5vpQH9JdBioUupqluzxSYxPLjhmqRUudk15adUl/ypnRsM2/M1kN3AmVJQeG7nZqcL68H8JlGqQQT6vy9A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -12419,6 +12670,25 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
+      "license": "MIT"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -12455,6 +12725,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12509,6 +12780,12 @@
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "license": "MIT"
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "license": "ISC"
     },
     "node_modules/ultrahtml": {
       "version": "1.6.0",
@@ -12970,81 +13247,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vite": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.4.tgz",
-      "integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.14"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
       }
     },
     "node_modules/vitefu": {
@@ -13983,7 +14185,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@astrojs/react": "^4.3.0",
     "@astrojs/rss": "^4.0.12",
     "@astrojs/sitemap": "^3.4.1",
+    "@iannuttall/seo-graph-astro": "^0.0.6",
+    "@iannuttall/seo-graph-core": "^0.0.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@resvg/resvg-js": "^2.6.2",
     "@tailwindcss/vite": "^4.1.11",
@@ -33,6 +35,7 @@
     "remark-toc": "^9.0.0",
     "sanitize-html": "^2.17.0",
     "satori": "^0.15.2",
+    "schema-dts": "^2.0.0",
     "sharp": "^0.34.2",
     "tailwindcss": "^4.1.11",
     "yet-another-react-lightbox": "^3.25.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "schema-dts": "^2.0.0",
     "sharp": "^0.34.2",
     "tailwindcss": "^4.1.11",
+    "vite": "^6.4.3",
     "yet-another-react-lightbox": "^3.25.0"
   },
   "devDependencies": {
@@ -47,6 +48,8 @@
     "@tailwindcss/typography": "^0.5.16",
     "@types/lodash.kebabcase": "^4.1.9",
     "@types/markdown-it": "^14.1.2",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
     "@types/sanitize-html": "^2.16.0",
     "@typescript-eslint/parser": "^8.36.0",
     "eslint": "^9.30.1",

--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -15,11 +15,21 @@ export interface Props {
 const { frontmatter } = Astro.props;
 ---
 
-<Layout title={`${frontmatter.title} | ${SITE.title}`}>
+<Layout
+  title={`${frontmatter.title} | ${SITE.title}`}
+  schemaKind="about"
+  breadcrumbs={[
+    { name: "Home", url: SITE.website },
+    { name: frontmatter.title, url: SITE.profile },
+  ]}
+>
   <Header />
   <Breadcrumb />
   <main id="main-content">
-    <section id="about" class="app-prose mb-28 max-w-content prose-img:border-0">
+    <section
+      id="about"
+      class="app-prose mb-28 max-w-content prose-img:border-0"
+    >
       <h1 class="text-2xl tracking-wider sm:text-3xl">{frontmatter.title}</h1>
       <slot />
     </section>

--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -17,6 +17,10 @@ const { frontmatter } = Astro.props;
 
 <Layout
   title={`${frontmatter.title} | ${SITE.title}`}
+  description={
+    frontmatter.description ??
+    "YJ Soon — teacher, designer, and programmer in Singapore. Co-founder of Tinkertanker."
+  }
   schemaKind="about"
   breadcrumbs={[
     { name: "Home", url: SITE.website },

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,6 +7,7 @@ import {
   buildSeoGraph,
   canonicalHref,
   defaultPageImage,
+  fallbackDescription,
   type BreadcrumbCrumb,
   type SchemaKind,
 } from "@/utils/seoGraph";
@@ -31,7 +32,7 @@ export interface Props {
 const {
   title = SITE.title,
   author = SITE.author,
-  description = SITE.desc,
+  description: rawDescription = SITE.desc,
   ogImage = SITE.ogImage ? `/${SITE.ogImage}` : "/og.png",
   canonicalURL = new URL(Astro.url.pathname, Astro.url),
   pubDatetime,
@@ -43,6 +44,7 @@ const {
   articleSection,
 } = Astro.props;
 
+const description = fallbackDescription(rawDescription);
 const socialImageURL = new URL(ogImage, Astro.url);
 const pageUrl = canonicalHref(canonicalURL);
 const structuredData = buildSeoGraph({

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,13 @@ import { ClientRouter } from "astro:transitions";
 import { PUBLIC_GOOGLE_SITE_VERIFICATION } from "astro:env/client";
 import { SITE } from "@/config";
 import Logo from "@/assets/logo.png";
+import {
+  buildSeoGraph,
+  canonicalHref,
+  defaultPageImage,
+  type BreadcrumbCrumb,
+  type SchemaKind,
+} from "@/utils/seoGraph";
 import "@/styles/global.css";
 
 export interface Props {
@@ -11,41 +18,52 @@ export interface Props {
   profile?: string;
   description?: string;
   ogImage?: string;
-  canonicalURL?: string;
+  canonicalURL?: string | URL;
   pubDatetime?: Date;
   modDatetime?: Date | null;
   scrollSmooth?: boolean;
+  schemaKind?: SchemaKind;
+  breadcrumbs?: BreadcrumbCrumb[];
+  headline?: string;
+  articleSection?: string;
 }
 
 const {
   title = SITE.title,
   author = SITE.author,
-  profile = SITE.profile,
   description = SITE.desc,
   ogImage = SITE.ogImage ? `/${SITE.ogImage}` : "/og.png",
   canonicalURL = new URL(Astro.url.pathname, Astro.url),
   pubDatetime,
   modDatetime,
   scrollSmooth = false,
+  schemaKind = "page",
+  breadcrumbs,
+  headline,
+  articleSection,
 } = Astro.props;
 
 const socialImageURL = new URL(ogImage, Astro.url);
-
-const structuredData = {
-  "@context": "https://schema.org",
-  "@type": "BlogPosting",
-  headline: `${title}`,
-  image: `${socialImageURL}`,
-  datePublished: `${pubDatetime?.toISOString()}`,
-  ...(modDatetime && { dateModified: modDatetime.toISOString() }),
-  author: [
-    {
-      "@type": "Person",
-      name: `${author}`,
-      ...(profile && { url: profile }),
-    },
-  ],
-};
+const pageUrl = canonicalHref(canonicalURL);
+const structuredData = buildSeoGraph({
+  kind: schemaKind,
+  url: pageUrl,
+  name: title,
+  description,
+  headline,
+  image:
+    ogImage === (SITE.ogImage ? `/${SITE.ogImage}` : "/og.png")
+      ? defaultPageImage()
+      : {
+          url: socialImageURL.href,
+          width: 1200,
+          height: 630,
+        },
+  datePublished: pubDatetime,
+  dateModified: modDatetime,
+  breadcrumbs,
+  articleSection,
+});
 ---
 
 <!doctype html>
@@ -143,20 +161,20 @@ const structuredData = {
     <slot />
     <script>
       function initEmailLinks() {
-        document.querySelectorAll('.js-email').forEach(el => {
-          const a = el.closest('a') || el;
-          const u = a.getAttribute('data-u');
-          const d = a.getAttribute('data-d');
+        document.querySelectorAll(".js-email").forEach(el => {
+          const a = el.closest("a") || el;
+          const u = a.getAttribute("data-u");
+          const d = a.getAttribute("data-d");
           if (u && d) {
-            a.addEventListener('click', (e) => {
+            a.addEventListener("click", e => {
               e.preventDefault();
-              window.location.href = 'mailto:' + u + '@' + d;
+              window.location.href = "mailto:" + u + "@" + d;
             });
           }
         });
       }
       initEmailLinks();
-      document.addEventListener('astro:after-swap', initEmailLinks);
+      document.addEventListener("astro:after-swap", initEmailLinks);
     </script>
   </body>
 </html>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -142,7 +142,9 @@ const nextPost =
       {tags.map(tag => <Tag tag={slugifyStr(tag)} tagName={tag} />)}
     </ul>
 
-    <BackToTopButton />
+    <div data-agent-markdown="exclude">
+      <BackToTopButton />
+    </div>
 
     <div data-agent-markdown="exclude">
       <ShareLinks />

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -65,6 +65,19 @@ const layoutProps = {
   canonicalURL,
   ogImage,
   scrollSmooth: true,
+  schemaKind: "post" as const,
+  headline: title,
+  articleSection: tags[0],
+  breadcrumbs: [
+    { name: "Home", url: SITE.website },
+    { name: "Posts", url: new URL("/posts", SITE.website).href },
+    {
+      name: title,
+      url:
+        canonicalURL ??
+        new URL(getPath(post.id, post.filePath), SITE.website).href,
+    },
+  ],
 };
 
 /* ========== Prev/Next Posts ========== */
@@ -108,7 +121,9 @@ const nextPost =
           { hidden: !SITE.editPost.enabled || hideEditPost },
         ]}>|</span
       >
-      <EditPost {hideEditPost} {post} class="max-sm:hidden" />
+      <span data-agent-markdown="exclude">
+        <EditPost {hideEditPost} {post} class="max-sm:hidden" />
+      </span>
     </div>
     <article
       id="article"
@@ -119,7 +134,9 @@ const nextPost =
 
     <hr class="my-8 border-dashed" />
 
-    <EditPost class="sm:hidden" {hideEditPost} {post} />
+    <div data-agent-markdown="exclude">
+      <EditPost class="sm:hidden" {hideEditPost} {post} />
+    </div>
 
     <ul class="mt-4 mb-8 sm:my-8">
       {tags.map(tag => <Tag tag={slugifyStr(tag)} tagName={tag} />)}
@@ -127,12 +144,18 @@ const nextPost =
 
     <BackToTopButton />
 
-    <ShareLinks />
+    <div data-agent-markdown="exclude">
+      <ShareLinks />
+    </div>
 
     <hr class="my-6 border-dashed" />
 
     <!-- Previous/Next Post Buttons -->
-    <div data-pagefind-ignore class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+    <div
+      data-pagefind-ignore
+      data-agent-markdown="exclude"
+      class="grid grid-cols-1 gap-6 sm:grid-cols-2"
+    >
       {
         prevPost && (
           <a

--- a/src/pages/.well-known/api-catalog.ts
+++ b/src/pages/.well-known/api-catalog.ts
@@ -6,19 +6,9 @@ export const GET = createApiCatalog({
   schemaEndpoints: [{ path: "/schema/blog.json", schemaType: "BlogPosting" }],
   schemaMap: { path: "/schemamap.xml" },
   additional: [
-    {
-      anchor: "/llms.txt",
-      type: "text/plain",
-      serviceDoc: "https://github.com/iannuttall/seo-graph",
-    },
-    {
-      anchor: "/rss.xml",
-      type: "application/rss+xml",
-    },
-    {
-      anchor: "/agent-routes.json",
-      type: "application/json",
-    },
+    { anchor: "/llms.txt" },
+    { anchor: "/rss.xml" },
+    { anchor: "/agent-routes.json" },
   ],
   cacheControl: "max-age=3600",
 });

--- a/src/pages/.well-known/api-catalog.ts
+++ b/src/pages/.well-known/api-catalog.ts
@@ -1,0 +1,24 @@
+import { createApiCatalog } from "@iannuttall/seo-graph-astro";
+import { SITE } from "@/config";
+
+export const GET = createApiCatalog({
+  siteUrl: SITE.website,
+  schemaEndpoints: [{ path: "/schema/blog.json", schemaType: "BlogPosting" }],
+  schemaMap: { path: "/schemamap.xml" },
+  additional: [
+    {
+      anchor: "/llms.txt",
+      type: "text/plain",
+      serviceDoc: "https://github.com/iannuttall/seo-graph",
+    },
+    {
+      anchor: "/rss.xml",
+      type: "application/rss+xml",
+    },
+    {
+      anchor: "/agent-routes.json",
+      type: "application/json",
+    },
+  ],
+  cacheControl: "max-age=3600",
+});

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -33,6 +33,7 @@ const months = [
 
 <Layout
   title={`Archives | ${SITE.title}`}
+  description="All the articles I've archived."
   schemaKind="collection"
   breadcrumbs={[
     { name: "Home", url: SITE.website },

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -31,7 +31,14 @@ const months = [
 ];
 ---
 
-<Layout title={`Archives | ${SITE.title}`}>
+<Layout
+  title={`Archives | ${SITE.title}`}
+  schemaKind="collection"
+  breadcrumbs={[
+    { name: "Home", url: SITE.website },
+    { name: "Archives", url: new URL("/archives", SITE.website).href },
+  ]}
+>
   <Header />
   <Main pageTitle="Archives" pageDesc="All the articles I've archived.">
     {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,7 +24,7 @@ const fullPosts = recentPosts.slice(0, 5);
 const headlinePosts = recentPosts.slice(5, 10);
 ---
 
-<Layout>
+<Layout schemaKind="home">
   <Header />
   <main id="main-content" data-layout="index">
     <section id="hero" class="py-8">

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -20,6 +20,7 @@ const { page } = Astro.props;
 
 <Layout
   title={`Posts | ${SITE.title}`}
+  description="All the articles I've posted."
   schemaKind="collection"
   breadcrumbs={[
     { name: "Home", url: SITE.website },

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -18,7 +18,22 @@ export const getStaticPaths = (async ({ paginate }) => {
 const { page } = Astro.props;
 ---
 
-<Layout title={`Posts | ${SITE.title}`}>
+<Layout
+  title={`Posts | ${SITE.title}`}
+  schemaKind="collection"
+  breadcrumbs={[
+    { name: "Home", url: SITE.website },
+    { name: "Posts", url: new URL("/posts", SITE.website).href },
+    ...(page.currentPage > 1
+      ? [
+          {
+            name: `Page ${page.currentPage}`,
+            url: new URL(Astro.url.pathname, SITE.website).href,
+          },
+        ]
+      : []),
+  ]}
+>
   <Header />
   <Main pageTitle="Posts" pageDesc="All the articles I've posted.">
     <ul>

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,13 +1,17 @@
 import type { APIRoute } from "astro";
 
-const getRobotsTxt = (sitemapURL: URL) => `
+const getRobotsTxt = (sitemapURL: URL, site: URL) => `
 User-agent: *
 Allow: /
 
 Sitemap: ${sitemapURL.href}
+
+# Agent discovery
+# ${new URL("llms.txt", site).href}
+# ${new URL(".well-known/api-catalog", site).href}
 `;
 
 export const GET: APIRoute = ({ site }) => {
   const sitemapURL = new URL("sitemap-index.xml", site);
-  return new Response(getRobotsTxt(sitemapURL));
+  return new Response(getRobotsTxt(sitemapURL, site ?? sitemapURL));
 };

--- a/src/pages/schema/blog.json.ts
+++ b/src/pages/schema/blog.json.ts
@@ -1,0 +1,30 @@
+import { getCollection, type CollectionEntry } from "astro:content";
+import { createSchemaEndpoint } from "@iannuttall/seo-graph-astro";
+import { SITE } from "@/config";
+import postFilter from "@/utils/postFilter";
+import { blogPostPieces, postCanonicalUrl, postImage } from "@/utils/seoGraph";
+
+function postPieces(post: CollectionEntry<"blog">) {
+  const url = postCanonicalUrl(post);
+  return blogPostPieces({
+    url,
+    name: `${post.data.title} | ${SITE.title}`,
+    headline: post.data.title,
+    description: post.data.description,
+    image: postImage(post),
+    datePublished: post.data.pubDatetime,
+    dateModified: post.data.modDatetime,
+    breadcrumbs: [
+      { name: "Home", url: SITE.website },
+      { name: "Posts", url: new URL("/posts", SITE.website).href },
+      { name: post.data.title, url },
+    ],
+    articleSection: post.data.tags[0],
+  });
+}
+
+export const GET = createSchemaEndpoint({
+  entries: async () => (await getCollection("blog")).filter(postFilter),
+  mapper: postPieces,
+  cacheControl: "max-age=3600",
+});

--- a/src/pages/schemamap.xml.ts
+++ b/src/pages/schemamap.xml.ts
@@ -1,0 +1,16 @@
+import { getCollection } from "astro:content";
+import { createSchemaMap } from "@iannuttall/seo-graph-astro";
+import { SITE } from "@/config";
+import postFilter from "@/utils/postFilter";
+
+const posts = (await getCollection("blog")).filter(postFilter);
+const lastModified = posts.reduce((latest, post) => {
+  const updated = post.data.modDatetime ?? post.data.pubDatetime;
+  return updated > latest ? updated : latest;
+}, new Date(0));
+
+export const GET = createSchemaMap({
+  siteUrl: SITE.website,
+  entries: [{ path: "/schema/blog.json", lastModified }],
+  cacheControl: "max-age=3600",
+});

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -9,7 +9,13 @@ import { SITE } from "@/config";
 const backUrl = SITE.showBackButton ? `${Astro.url.pathname}` : "/";
 ---
 
-<Layout title={`Search | ${SITE.title}`}>
+<Layout
+  title={`Search | ${SITE.title}`}
+  breadcrumbs={[
+    { name: "Home", url: SITE.website },
+    { name: "Search", url: new URL("/search", SITE.website).href },
+  ]}
+>
   <Header />
   <Main pageTitle="Search" pageDesc="Search any article ...">
     <div id="pagefind-search" transition:persist data-backurl={backUrl}></div>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -11,6 +11,7 @@ const backUrl = SITE.showBackButton ? `${Astro.url.pathname}` : "/";
 
 <Layout
   title={`Search | ${SITE.title}`}
+  description="Search any article ..."
   breadcrumbs={[
     { name: "Home", url: SITE.website },
     { name: "Search", url: new URL("/search", SITE.website).href },

--- a/src/pages/tags/[tag]/[...page].astro
+++ b/src/pages/tags/[tag]/[...page].astro
@@ -31,7 +31,23 @@ const { tag } = params;
 const { page, tagName } = Astro.props;
 ---
 
-<Layout title={`Tag: ${tagName} | ${SITE.title}`}>
+<Layout
+  title={`Tag: ${tagName} | ${SITE.title}`}
+  schemaKind="collection"
+  breadcrumbs={[
+    { name: "Home", url: SITE.website },
+    { name: "Tags", url: new URL("/tags", SITE.website).href },
+    { name: tagName, url: new URL(`/tags/${tag}`, SITE.website).href },
+    ...(page.currentPage > 1
+      ? [
+          {
+            name: `Page ${page.currentPage}`,
+            url: new URL(Astro.url.pathname, SITE.website).href,
+          },
+        ]
+      : []),
+  ]}
+>
   <Header />
   <Main
     pageTitle={[`Tag:`, `${tagName}`]}

--- a/src/pages/tags/[tag]/[...page].astro
+++ b/src/pages/tags/[tag]/[...page].astro
@@ -33,6 +33,7 @@ const { page, tagName } = Astro.props;
 
 <Layout
   title={`Tag: ${tagName} | ${SITE.title}`}
+  description={`All the articles with the tag "${tagName}".`}
   schemaKind="collection"
   breadcrumbs={[
     { name: "Home", url: SITE.website },

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -13,7 +13,14 @@ const posts = await getCollection("blog");
 let tags = getUniqueTags(posts);
 ---
 
-<Layout title={`Tags | ${SITE.title}`}>
+<Layout
+  title={`Tags | ${SITE.title}`}
+  schemaKind="collection"
+  breadcrumbs={[
+    { name: "Home", url: SITE.website },
+    { name: "Tags", url: new URL("/tags", SITE.website).href },
+  ]}
+>
   <Header />
   <Main pageTitle="Tags" pageDesc="All the tags used in posts.">
     <ul>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -15,6 +15,7 @@ let tags = getUniqueTags(posts);
 
 <Layout
   title={`Tags | ${SITE.title}`}
+  description="All the tags used in posts."
   schemaKind="collection"
   breadcrumbs={[
     { name: "Home", url: SITE.website },

--- a/src/utils/seoGraph.ts
+++ b/src/utils/seoGraph.ts
@@ -56,13 +56,13 @@ const PERSON_SAME_AS = [
 
 export const ids = makeIds({
   siteUrl: SITE.website,
-  personUrl: SITE.profile,
+  personUrl: pageUrl(SITE.profile),
 });
 
 export const origin = SITE.website.replace(/\/+$/, "");
 export const blogId = `${origin}${BLOG_PATH}/#blog`;
-export const blogUrl = absoluteUrl(BLOG_PATH);
-export const aboutUrl = SITE.profile;
+export const blogUrl = pageUrl(BLOG_PATH);
+export const aboutUrl = pageUrl(SITE.profile);
 export const language = SITE.lang || "en";
 
 export const personImage: SeoImage = {
@@ -76,13 +76,27 @@ export function absoluteUrl(path: string): string {
   return new URL(path, SITE.website).href;
 }
 
+/** HTML page URL with a trailing slash, matching Astro's directory output. */
+export function pageUrl(path: string): string {
+  const url = new URL(absoluteUrl(path));
+  if (url.search || url.hash) return url.href;
+  if (url.pathname !== "/" && !url.pathname.endsWith("/")) {
+    url.pathname = `${url.pathname}/`;
+  }
+  return url.href;
+}
+
 export function canonicalHref(url: string | URL): string {
-  return new URL(url, SITE.website).href;
+  return pageUrl(String(url));
+}
+
+export function fallbackDescription(value?: string | null): string {
+  return value?.trim() || SITE.desc;
 }
 
 export function postCanonicalUrl(post: CollectionEntry<"blog">): string {
   if (post.data.canonicalURL) return canonicalHref(post.data.canonicalURL);
-  return absoluteUrl(getPath(post.id, post.filePath));
+  return pageUrl(getPath(post.id, post.filePath));
 }
 
 export function postImage(post: CollectionEntry<"blog">): SeoImage {
@@ -186,9 +200,9 @@ export function siteWidePieces(): GraphEntity[] {
           { name: "Home", url: SITE.website },
           { name: "About", url: aboutUrl },
           { name: "Posts", url: blogUrl },
-          { name: "Tags", url: absoluteUrl("/tags") },
+          { name: "Tags", url: pageUrl("/tags") },
           ...(SITE.showArchives
-            ? [{ name: "Archives", url: absoluteUrl("/archives") }]
+            ? [{ name: "Archives", url: pageUrl("/archives") }]
             : []),
         ],
       },
@@ -230,6 +244,7 @@ export function blogPostPieces(input: {
 
 export function buildSeoGraphPieces(input: BuildSeoGraphInput): GraphEntity[] {
   const url = canonicalHref(input.url);
+  const description = fallbackDescription(input.description);
   const image = input.image ?? defaultPageImage();
   const pageType = pageTypeForKind(input.kind);
   const about =
@@ -245,7 +260,7 @@ export function buildSeoGraphPieces(input: BuildSeoGraphInput): GraphEntity[] {
       {
         url,
         name: input.name,
-        description: input.description,
+        description,
         isPartOf: { "@id": ids.website },
         inLanguage: language,
         datePublished: input.datePublished,
@@ -282,7 +297,7 @@ export function buildSeoGraphPieces(input: BuildSeoGraphInput): GraphEntity[] {
           url,
           items: input.breadcrumbs.map(item => ({
             name: item.name,
-            url: canonicalHref(item.url),
+            url: pageUrl(item.url),
           })),
         },
         ids
@@ -296,7 +311,7 @@ export function buildSeoGraphPieces(input: BuildSeoGraphInput): GraphEntity[] {
         {
           url,
           headline: input.headline ?? input.name,
-          description: input.description,
+          description,
           datePublished: input.datePublished,
           dateModified: input.dateModified ?? undefined,
           author: { "@id": ids.person },

--- a/src/utils/seoGraph.ts
+++ b/src/utils/seoGraph.ts
@@ -1,0 +1,324 @@
+import type { CollectionEntry } from "astro:content";
+import type { Blog, Organization, Person } from "schema-dts";
+import {
+  assembleGraph,
+  buildArticle,
+  buildBreadcrumbList,
+  buildImageObject,
+  buildPiece,
+  buildSiteNavigationElement,
+  buildWebPage,
+  buildWebSite,
+  makeIds,
+  type GraphEntity,
+  type WebPageType,
+} from "@iannuttall/seo-graph-core";
+import personPhoto from "@/assets/logo.png";
+import { SITE } from "@/config";
+import { getPath } from "@/utils/getPath";
+
+export type SchemaKind = "home" | "about" | "collection" | "page" | "post";
+
+export interface BreadcrumbCrumb {
+  name: string;
+  url: string;
+}
+
+export interface SeoImage {
+  url: string;
+  width: number;
+  height: number;
+}
+
+export interface BuildSeoGraphInput {
+  kind: SchemaKind;
+  url: string;
+  name: string;
+  description: string;
+  image?: SeoImage;
+  datePublished?: Date;
+  dateModified?: Date | null;
+  breadcrumbs?: BreadcrumbCrumb[];
+  headline?: string;
+  articleSection?: string;
+}
+
+export const OG_IMAGE_SIZE = { width: 1200, height: 630 } as const;
+export const CONTENT_LICENSE = "https://creativecommons.org/licenses/by/4.0/";
+export const BLOG_PATH = "/posts";
+
+const PERSON_SAME_AS = [
+  "https://x.com/yjsoon",
+  "https://threads.net/@yjsoon",
+  "https://www.linkedin.com/in/yjsoon",
+  "https://www.github.com/yjsoon",
+] as const;
+
+export const ids = makeIds({
+  siteUrl: SITE.website,
+  personUrl: SITE.profile,
+});
+
+export const origin = SITE.website.replace(/\/+$/, "");
+export const blogId = `${origin}${BLOG_PATH}/#blog`;
+export const blogUrl = absoluteUrl(BLOG_PATH);
+export const aboutUrl = SITE.profile;
+export const language = SITE.lang || "en";
+
+export const personImage: SeoImage = {
+  url: absoluteUrl(personPhoto.src),
+  width: personPhoto.width ?? 300,
+  height: personPhoto.height ?? 300,
+};
+
+export function absoluteUrl(path: string): string {
+  if (/^https?:\/\//u.test(path)) return path;
+  return new URL(path, SITE.website).href;
+}
+
+export function canonicalHref(url: string | URL): string {
+  return new URL(url, SITE.website).href;
+}
+
+export function postCanonicalUrl(post: CollectionEntry<"blog">): string {
+  if (post.data.canonicalURL) return canonicalHref(post.data.canonicalURL);
+  return absoluteUrl(getPath(post.id, post.filePath));
+}
+
+export function postImage(post: CollectionEntry<"blog">): SeoImage {
+  const ogImage = post.data.ogImage;
+  if (typeof ogImage === "string") {
+    return { url: absoluteUrl(ogImage), ...OG_IMAGE_SIZE };
+  }
+  if (ogImage?.src) {
+    return {
+      url: absoluteUrl(ogImage.src),
+      width: ogImage.width ?? OG_IMAGE_SIZE.width,
+      height: ogImage.height ?? OG_IMAGE_SIZE.height,
+    };
+  }
+  if (SITE.dynamicOgImage) {
+    return {
+      url: absoluteUrl(`${getPath(post.id, post.filePath)}/index.png`),
+      ...OG_IMAGE_SIZE,
+    };
+  }
+  return defaultPageImage();
+}
+
+export function defaultPageImage(): SeoImage {
+  return { url: absoluteUrl(`/${SITE.ogImage}`), ...OG_IMAGE_SIZE };
+}
+
+export function siteWidePieces(): GraphEntity[] {
+  return [
+    buildWebSite(
+      {
+        url: SITE.website,
+        name: SITE.title,
+        description: SITE.desc,
+        publisher: { "@id": ids.person },
+        about: { "@id": ids.person },
+        inLanguage: language,
+        hasPart: { "@id": ids.navigation },
+        potentialAction: {
+          "@type": "SearchAction",
+          target: {
+            "@type": "EntryPoint",
+            urlTemplate: `${origin}/search?q={search_term_string}`,
+          },
+        },
+      },
+      ids
+    ),
+    buildPiece<Person>({
+      "@type": "Person",
+      "@id": ids.person,
+      name: SITE.author,
+      url: aboutUrl,
+      description:
+        "Teacher, designer, and programmer based in Singapore. Co-founder of Tinkertanker.",
+      jobTitle: "Teacher, designer, and programmer",
+      image: { "@id": ids.personImage },
+      sameAs: [...PERSON_SAME_AS],
+      nationality: { "@type": "Country", name: "Singapore" },
+      knowsLanguage: language,
+      knowsAbout: [
+        "Programming",
+        "Teaching",
+        "Design",
+        "Education",
+        "Artificial intelligence",
+      ],
+      worksFor: { "@id": ids.organization("tinkertanker") },
+    }),
+    buildImageObject(
+      {
+        id: ids.personImage,
+        url: personImage.url,
+        width: personImage.width,
+        height: personImage.height,
+        caption: SITE.author,
+        inLanguage: language,
+      },
+      ids
+    ),
+    buildPiece<Organization>({
+      "@type": "Organization",
+      "@id": ids.organization("tinkertanker"),
+      name: "Tinkertanker",
+      url: "https://tinkertanker.com",
+    }),
+    buildPiece<Blog>({
+      "@type": "Blog",
+      "@id": blogId,
+      name: SITE.title,
+      description: SITE.desc,
+      url: blogUrl,
+      publisher: { "@id": ids.person },
+      inLanguage: language,
+    }),
+    buildSiteNavigationElement(
+      {
+        name: "Main navigation",
+        isPartOf: { "@id": ids.website },
+        items: [
+          { name: "Home", url: SITE.website },
+          { name: "About", url: aboutUrl },
+          { name: "Posts", url: blogUrl },
+          { name: "Tags", url: absoluteUrl("/tags") },
+          ...(SITE.showArchives
+            ? [{ name: "Archives", url: absoluteUrl("/archives") }]
+            : []),
+        ],
+      },
+      ids
+    ),
+  ];
+}
+
+function pageTypeForKind(kind: SchemaKind): WebPageType {
+  if (kind === "about") return "ProfilePage";
+  if (kind === "home" || kind === "collection") return "CollectionPage";
+  return "WebPage";
+}
+
+export function blogPostPieces(input: {
+  url: string;
+  name: string;
+  description: string;
+  headline?: string;
+  image: SeoImage;
+  datePublished: Date;
+  dateModified?: Date | null;
+  breadcrumbs?: BreadcrumbCrumb[];
+  articleSection?: string;
+}): GraphEntity[] {
+  return buildSeoGraphPieces({
+    kind: "post",
+    url: input.url,
+    name: input.name,
+    description: input.description,
+    headline: input.headline,
+    image: input.image,
+    datePublished: input.datePublished,
+    dateModified: input.dateModified,
+    breadcrumbs: input.breadcrumbs,
+    articleSection: input.articleSection,
+  });
+}
+
+export function buildSeoGraphPieces(input: BuildSeoGraphInput): GraphEntity[] {
+  const url = canonicalHref(input.url);
+  const image = input.image ?? defaultPageImage();
+  const pageType = pageTypeForKind(input.kind);
+  const about =
+    input.kind === "home" || input.kind === "about"
+      ? { "@id": ids.person }
+      : input.kind === "collection"
+        ? { "@id": blogId }
+        : undefined;
+
+  const pieces: GraphEntity[] = [
+    ...siteWidePieces(),
+    buildWebPage(
+      {
+        url,
+        name: input.name,
+        description: input.description,
+        isPartOf: { "@id": ids.website },
+        inLanguage: language,
+        datePublished: input.datePublished,
+        dateModified: input.dateModified ?? undefined,
+        primaryImage: { "@id": ids.primaryImage(url) },
+        about,
+        copyrightHolder: { "@id": ids.person },
+        license: CONTENT_LICENSE,
+        isAccessibleForFree: true,
+        ...(input.breadcrumbs?.length
+          ? { breadcrumb: { "@id": ids.breadcrumb(url) } }
+          : {}),
+      },
+      ids,
+      pageType
+    ),
+    buildImageObject(
+      {
+        pageUrl: url,
+        url: image.url,
+        width: image.width,
+        height: image.height,
+        inLanguage: language,
+        caption: input.headline ?? input.name,
+      },
+      ids
+    ),
+  ];
+
+  if (input.breadcrumbs?.length) {
+    pieces.push(
+      buildBreadcrumbList(
+        {
+          url,
+          items: input.breadcrumbs.map(item => ({
+            name: item.name,
+            url: canonicalHref(item.url),
+          })),
+        },
+        ids
+      )
+    );
+  }
+
+  if (input.kind === "post" && input.datePublished) {
+    pieces.push(
+      buildArticle(
+        {
+          url,
+          headline: input.headline ?? input.name,
+          description: input.description,
+          datePublished: input.datePublished,
+          dateModified: input.dateModified ?? undefined,
+          author: { "@id": ids.person },
+          publisher: { "@id": ids.person },
+          isPartOf: [{ "@id": ids.webPage(url) }, { "@id": blogId }],
+          image: { "@id": ids.primaryImage(url) },
+          inLanguage: language,
+          articleSection: input.articleSection,
+          license: CONTENT_LICENSE,
+          isAccessibleForFree: true,
+        },
+        ids,
+        "BlogPosting"
+      )
+    );
+  }
+
+  return pieces;
+}
+
+export function buildSeoGraph(input: BuildSeoGraphInput) {
+  return assembleGraph(buildSeoGraphPieces(input), {
+    warnOnDanglingReferences: true,
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Installs [seo-graph](https://github.com/iannuttall/seo-graph) so the site serves a linked schema.org graph for search engines and deterministic Markdown twins for agents.

## What changed

- Replaced the homepage-and-posts `BlogPosting` blob with the personal-blog recipe: `WebSite`, `Person`, `Blog`, navigation, plus per-page `WebPage` / `ProfilePage` / `CollectionPage` and `BlogPosting`.
- Added the `agentMarkdown()` build integration for `.md` twins, `llms.txt`, `agent-routes.json`, and Cloudflare `_headers` for those Markdown routes.
- Added discovery endpoints: `/schema/blog.json`, `/schemamap.xml`, and `/.well-known/api-catalog`.
- Documented the setup in `docs/seo-graph.md`.

## Compatibility note

`@iannuttall/seo-graph-astro` lists Astro 7 as an optional peer. This site stays on Astro 5. `.npmrc` sets `legacy-peer-deps=true` so installs succeed. That also nests some transitive packages, so `vite` and the React types are now direct dependencies. The hooks we use exist in Astro 5.

Astro 7 is a separate follow-up: [#11](https://github.com/yjsoon/blog/issues/11).

## Intentionally not included

- Collection-source `.md` endpoints (they would collide with the build-time twins).
- IndexNow (needs a production key and submit step).
- Runtime `Accept: text/markdown` negotiation (needs a Worker; this is a static Pages deploy).

## Verification

- `npm run lint` passes.
- `npm run build` passes and emits 60 Markdown alternatives, `llms.txt`, `agent-routes.json`, `/schema/blog.json`, and `/.well-known/api-catalog`.
- `npm run format:check` still fails on pre-existing files (including an HTML comment in `src/pages/index.astro`); no new format drift in the files this PR touches.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7751d552-1ea2-4228-b661-67e5ac75e6fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7751d552-1ea2-4228-b661-67e5ac75e6fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

